### PR TITLE
docs: align README E2 node ID examples with xApp defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,12 @@ To start the provided example [xApp](xApps/python/simple_mon_xapp.py), please ru
 docker compose exec python_xapp_runner ./simple_mon_xapp.py --metrics=DRB.UEThpDl,DRB.UEThpUl
 ```
 
+**Note:** Example xApps default to `--e2_node_id gnbd_001_001_00019b_0`. Use the E2 node ID reported by your gNB/E2 agent if it differs (see [#26](https://github.com/srsran/oran-sc-ric/issues/26)).
+
 The xApp should subscribe to `DRB.UEThpUl` and `DRB.UEThpUl` measurements, and display the content of received `RIC_INDICATION` messages. The console output should be similar to:
 
 ```console
-RIC Indication Received from gnb_001_001_0000019b for Subscription ID: 65
+RIC Indication Received from gnbd_001_001_00019b_0 for Subscription ID: 65
 E2SM_KPM RIC Indication Content:
 -ColletStartTime:  2024-01-26 00:08:05
 -Measurements Data:
@@ -160,10 +162,10 @@ docker compose exec python_xapp_runner ./simple_rc_xapp.py
 The example RC xApp periodically (every 5s) adjusts the number of DL PRBs available for allocation to a UE. Its console output should be similar to:
 
 ```console
-11:34:29 Send RIC Control Request to E2 node ID: gnb_001_001_00019b for UE ID: 0, PRB_min: 1, PRB_max: 5
-11:34:34 Send RIC Control Request to E2 node ID: gnb_001_001_00019b for UE ID: 0, PRB_min: 1, PRB_max: 275
-11:34:39 Send RIC Control Request to E2 node ID: gnb_001_001_00019b for UE ID: 0, PRB_min: 1, PRB_max: 5
-11:34:44 Send RIC Control Request to E2 node ID: gnb_001_001_00019b for UE ID: 0, PRB_min: 1, PRB_max: 275
+11:34:29 Send RIC Control Request to E2 node ID: gnbd_001_001_00019b_0 for UE ID: 0, PRB_min: 1, PRB_max: 5
+11:34:34 Send RIC Control Request to E2 node ID: gnbd_001_001_00019b_0 for UE ID: 0, PRB_min: 1, PRB_max: 275
+11:34:39 Send RIC Control Request to E2 node ID: gnbd_001_001_00019b_0 for UE ID: 0, PRB_min: 1, PRB_max: 5
+11:34:44 Send RIC Control Request to E2 node ID: gnbd_001_001_00019b_0 for UE ID: 0, PRB_min: 1, PRB_max: 275
 ...
 ```
 
@@ -173,13 +175,13 @@ Enabling gNB console trace (with `t`) allows the monitoring of changes in the do
 **Note 5:** To trigger a handover with [simple_rc_ho_xapp](xApps/python/simple_rc_ho_xapp.py), use the following command:
 
 ```bash
-docker compose exec python_xapp_runner ./simple_rc_ho_xapp.py --e2_node_id gnb_001_001_0000019b --plmn 00101 --amf_ue_ngap_id 1 --target_nr_cell_id 0x19b1
+docker compose exec python_xapp_runner ./simple_rc_ho_xapp.py --e2_node_id gnbd_001_001_00019b_0 --plmn 00101 --amf_ue_ngap_id 1 --target_nr_cell_id 0x19b1
 ```
 
 To trigger another handover:
 
 ```bash
-docker compose exec python_xapp_runner ./simple_rc_ho_xapp.py --e2_node_id gnb_001_001_0000019b --plmn 00101 --amf_ue_ngap_id 1 --target_nr_cell_id 0x19b0
+docker compose exec python_xapp_runner ./simple_rc_ho_xapp.py --e2_node_id gnbd_001_001_00019b_0 --plmn 00101 --amf_ue_ngap_id 1 --target_nr_cell_id 0x19b0
 ```
 
 Note that everytime UE connects to the network it gets assigned a new AMF UE NGAP ID.


### PR DESCRIPTION
### Why

Several xApps default to `--e2_node_id gnbd_001_001_00019b_0`, but README examples still use the legacy `gnb_001_001_*` form. This matches confusion reported in #26 and causes copy-paste failures when running RC / handover examples.

This is a **docs-only** change — no runtime behavior change.

### Changes

- Update README command examples to use `gnbd_001_001_00019b_0`
- Update sample console output to use consistent E2 node ID format
- Add a short note under Example xApp pointing to `--e2_node_id` default in xApp CLIs

### How we found it

Running [orca-runner](https://github.com/dasmlab/orca-runner) with `policies/oran-xapp-srsran-lab.yaml` flags `readme-e2-id-mismatch` (T-E2) on the repo while validating the docker lab.

### Testing

Docs only — verified xApp defaults:

```bash
grep -r "default='gnbd_" xApps/python/*.py
```

### Related

- Issue #26 (E2 agent ID mismatch)
- orca-runner roadmap (public): https://github.com/dasmlab/orca-runner/blob/main/docs/00-roadmap.md
- CI security gate discussion is intentionally **not** part of this PR — follow-up after lab validation