### PR TITLE
Enable external access for e2term service port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,9 +72,9 @@ services:
     container_name: ric_e2term
     hostname: e2term
     image: nexus3.o-ran-sc.org:10002/o-ran-sc/ric-plt-e2:${E2TERM_VER}
-    #Uncomment ports to use the RIC from outside the docker network.
-    #ports:
-    #  - "36421:36421/sctp"
+    #Comment ports to use the RIC from inside the docker network.
+    ports:
+      - "36421:36421/sctp"
     env_file:
       - .env
     environment:


### PR DESCRIPTION
Uncomments the port configuration for the `e2term` service to allow external access to the Near-RT RIC. 

This improves the out-of-the-box experience: running `docker compose up` is now enough to connect external components (e.g., a local gNB/OCUDU installation on the host) directly to the RIC without manual configuration.